### PR TITLE
fixes missing or wrong text domain for translatable text strings

### DIFF
--- a/includes/MPSUM_Plugins_List_Table.php
+++ b/includes/MPSUM_Plugins_List_Table.php
@@ -8,7 +8,7 @@
  * @access private
  */
 class MPSUM_Plugins_List_Table extends MPSUM_List_Table {
-	
+
 	private $tab = '';
 
 	/**
@@ -28,9 +28,9 @@ class MPSUM_Plugins_List_Table extends MPSUM_List_Table {
 			'plural' => 'plugins',
 			'screen' => isset( $args['screen'] ) ? $args['screen'] : null,
 		) );
-		
+
 		$this->tab = isset( $args[ 'tab' ] ) ? $args[ 'tab' ] : '';
-		
+
 
 		$status = 'all';
 		if ( isset( $_REQUEST['plugin_status'] ) && in_array( $_REQUEST['plugin_status'], array( 'update_disabled', 'update_enabled', 'automatic' ) ) ) {
@@ -52,7 +52,7 @@ class MPSUM_Plugins_List_Table extends MPSUM_List_Table {
 	}
 
 	public function prepare_items() {
-		
+
 		global $orderby, $order, $totals, $status;
 		$order = 'DESC';
 		$page = isset( $_GET[ 'paged' ] ) ? absint( $_GET[ 'paged' ] ) : 1;
@@ -76,9 +76,9 @@ class MPSUM_Plugins_List_Table extends MPSUM_List_Table {
 
 		$screen = $this->screen;
 
-		
+
 		$plugin_info = get_site_transient( 'update_plugins' );
-		
+
 		$plugin_options = MPSUM_Updates_Manager::get_options( 'plugins' );
 		$plugin_automatic_options = MPSUM_Updates_Manager::get_options( 'plugins_automatic' );
 		foreach ( (array) $plugins['all'] as $plugin_file => $plugin_data ) {
@@ -88,8 +88,8 @@ class MPSUM_Plugins_List_Table extends MPSUM_List_Table {
 			} elseif ( isset( $plugin_info->no_update[ $plugin_file ] ) ) {
 				$plugins['all'][ $plugin_file ] = $plugin_data = array_merge( (array) $plugin_info->no_update[ $plugin_file ], $plugin_data );
 			}
-			
-			
+
+
 			if ( false !== $key = array_search( $plugin_file, $plugin_options ) ) {
 				$plugins[ 'update_disabled' ][ $plugin_file ] = $plugin_data;
 			} else {
@@ -99,18 +99,18 @@ class MPSUM_Plugins_List_Table extends MPSUM_List_Table {
 				}
 			}
 		}
-		
+
 		$totals = array();
 		foreach ( $plugins as $type => $list )
 			$totals[ $type ] = count( $list );
-			
+
 		//Disable the automatic updates view
 		$core_options = MPSUM_Updates_Manager::get_options( 'core' );
 		if ( isset( $core_options[ 'automatic_plugin_updates' ] ) && 'individual' !== $core_options[ 'automatic_plugin_updates' ] ) {
 			unset( $totals[ 'automatic' ] );
 			$plugins[ 'automatic' ] = array();
 		}
-		
+
 		if ( empty( $plugins[ $status ] ) )
 			$status = 'all';
 
@@ -124,12 +124,12 @@ class MPSUM_Plugins_List_Table extends MPSUM_List_Table {
 		$total_this_page = $totals[ $status ];
 
 		$plugins_per_page = 999;
-		
+
 		$start = ( $page - 1 ) * $plugins_per_page;
 
 		if ( $total_this_page > $plugins_per_page )
 			$this->items = array_slice( $this->items, $start, $plugins_per_page );
-		
+
 		$this->set_pagination_args( array(
 			'total_items' => $total_this_page,
 			'per_page' => $plugins_per_page,
@@ -181,9 +181,9 @@ class MPSUM_Plugins_List_Table extends MPSUM_List_Table {
 		global $plugins;
 
 		if ( !empty( $plugins['all'] ) )
-			_e( 'No plugins found.' );
+			_e( 'No plugins found.', 'stops-core-theme-and-plugin-updates');
 		else
-			_e( 'You do not appear to have any plugins available at this time.' );
+			_e( 'You do not appear to have any plugins available at this time.', 'stops-core-theme-and-plugin-updates' );
 	}
 
 	public function get_columns() {
@@ -191,8 +191,8 @@ class MPSUM_Plugins_List_Table extends MPSUM_List_Table {
 
 		return array(
 			'cb'          => !in_array( $status, array( 'mustuse', 'dropins' ) ) ? '<input type="checkbox" />' : '',
-			'name'        => __( 'Plugin' ),
-			'description' => __( 'Description' ),
+			'name'        => __( 'Plugin' , 'stops-core-theme-and-plugin-updates' ),
+			'description' => __( 'Description', 'stops-core-theme-and-plugin-updates' ),
 		);
 	}
 
@@ -244,15 +244,15 @@ class MPSUM_Plugins_List_Table extends MPSUM_List_Table {
 		global $status;
 
 		$actions = array();
-		        
-		$actions[ 'allow-update-selected' ] = esc_html__( 'Allow Updates', 'disable-plugin-and-theme-updates' );
-		$actions[ 'disallow-update-selected' ] = esc_html__( 'Disallow Updates', 'disable-plugin-and-theme-updates' );
+
+		$actions[ 'allow-update-selected' ] = esc_html__( 'Allow Updates', 'stops-core-theme-and-plugin-updates' );
+		$actions[ 'disallow-update-selected' ] = esc_html__( 'Disallow Updates', 'stops-core-theme-and-plugin-updates' );
 		$core_options = MPSUM_Updates_Manager::get_options( 'core' );
 		if ( isset( $core_options[ 'automatic_plugin_updates' ] ) && 'individual' == $core_options[ 'automatic_plugin_updates' ] ) {
-			$actions[ 'allow-automatic-selected' ] = esc_html__( 'Allow Automatic Updates', 'disable-plugin-and-theme-updates' );
-			$actions[ 'disallow-automatic-selected' ] = esc_html__( 'Disallow Automatic Updates', 'disable-plugin-and-theme-updates' );
+			$actions[ 'allow-automatic-selected' ] = esc_html__( 'Allow Automatic Updates', 'stops-core-theme-and-plugin-updates' );
+			$actions[ 'disallow-automatic-selected' ] = esc_html__( 'Disallow Automatic Updates', 'stops-core-theme-and-plugin-updates' );
 		}
-		
+
 		return $actions;
 	}
 
@@ -284,11 +284,11 @@ class MPSUM_Plugins_List_Table extends MPSUM_List_Table {
 		echo '<div class="alignleft actions">';
 
 		if ( ! $this->screen->in_admin( 'network' ) && 'recently_activated' == $status )
-			submit_button( __( 'Clear List' ), 'button', 'clear-recent-list', false );
+			submit_button( __( 'Clear List', 'stops-core-theme-and-plugin-updates' ), 'button', 'clear-recent-list', false );
 		elseif ( 'top' == $which && 'mustuse' == $status )
-			echo '<p>' . sprintf( __( 'Files in the <code>%s</code> directory are executed automatically.' ), str_replace( ABSPATH, '/', WPMU_PLUGIN_DIR ) ) . '</p>';
+			echo '<p>' . sprintf( __( 'Files in the <code>%s</code> directory are executed automatically.', 'stops-core-theme-and-plugin-updates' ), str_replace( ABSPATH, '/', WPMU_PLUGIN_DIR ) ) . '</p>';
 		elseif ( 'top' == $which && 'dropins' == $status )
-			echo '<p>' . sprintf( __( 'Drop-ins are advanced plugins in the <code>%s</code> directory that replace WordPress functionality when present.' ), str_replace( ABSPATH, '', WP_CONTENT_DIR ) ) . '</p>';
+			echo '<p>' . sprintf( __( 'Drop-ins are advanced plugins in the <code>%s</code> directory that replace WordPress functionality when present.', 'stops-core-theme-and-plugin-updates' ), str_replace( ABSPATH, '', WP_CONTENT_DIR ) ) . '</p>';
 
 		echo '</div>';
 	}
@@ -323,7 +323,7 @@ class MPSUM_Plugins_List_Table extends MPSUM_List_Table {
 		list( $plugin_file, $plugin_data ) = $item;
 		$context = 'all';
 		$screen = $this->screen;
-		
+
 		/**
 		* Filter the action links that show up under each plugin row.
 		*
@@ -339,9 +339,9 @@ class MPSUM_Plugins_List_Table extends MPSUM_List_Table {
 		$plugin_options = MPSUM_Updates_Manager::get_options( 'plugins' );
 		if ( false !== $key = array_search( $plugin_file, $plugin_options ) ) {
 			$class = 'inactive';
-		} 
+		}
 		$checkbox_id =  "checkbox_" . md5($plugin_data['Name']);
-		$checkbox = "<label class='screen-reader-text' for='" . $checkbox_id . "' >" . sprintf( __( 'Select %s' ), $plugin_data['Name'] ) . "</label>"
+		$checkbox = "<label class='screen-reader-text' for='" . $checkbox_id . "' >" . sprintf( __( 'Select %s', 'stops-core-theme-and-plugin-updates', , 'stops-core-theme-and-plugin-updates' ), $plugin_data['Name'] ) . "</label>"
 				. "<input type='checkbox' name='checked[]' value='" . esc_attr( $plugin_file ) . "' id='" . $checkbox_id . "' />";
 		$description = '<p>' . ( $plugin_data['Description'] ? $plugin_data['Description'] : '&nbsp;' ) . '</p>';
 		$plugin_name = $plugin_data['Name'];
@@ -378,7 +378,7 @@ class MPSUM_Plugins_List_Table extends MPSUM_List_Table {
 						$author = $plugin_data['Author'];
 						if ( !empty( $plugin_data['AuthorURI'] ) )
 							$author = '<a href="' . $plugin_data['AuthorURI'] . '">' . $plugin_data['Author'] . '</a>';
-						$plugin_meta[] = sprintf( __( 'By %s' ), $author );
+						$plugin_meta[] = sprintf( __( 'By %s', , 'stops-core-theme-and-plugin-updates' ), $author );
 					}
 
 					// Details link using API info, if available
@@ -386,14 +386,14 @@ class MPSUM_Plugins_List_Table extends MPSUM_List_Table {
 						$plugin_meta[] = sprintf( '<a href="%s" class="thickbox" aria-label="%s" data-title="%s">%s</a>',
 							esc_url( network_admin_url( 'plugin-install.php?tab=plugin-information&plugin=' . $plugin_data['slug'] .
 								'&TB_iframe=true&width=600&height=550' ) ),
-							esc_attr( sprintf( __( 'More information about %s' ), $plugin_name ) ),
+							esc_attr( sprintf( __( 'More information about %s' ), , 'stops-core-theme-and-plugin-updates' ) ),
 							esc_attr( $plugin_name ),
-							__( 'View details' )
+							__( 'View details', 'stops-core-theme-and-plugin-updates' )
 						);
 					} elseif ( ! empty( $plugin_data['PluginURI'] ) ) {
 						$plugin_meta[] = sprintf( '<a href="%s">%s</a>',
 							esc_url( $plugin_data['PluginURI'] ),
-							__( 'Visit plugin site' )
+							__( 'Visit plugin site', 'stops-core-theme-and-plugin-updates' )
 						);
 					}
 

--- a/includes/MPSUM_Themes_List_Table.php
+++ b/includes/MPSUM_Themes_List_Table.php
@@ -30,7 +30,7 @@ class MPSUM_Themes_List_Table extends MPSUM_List_Table {
 			'plural' => 'themes',
 			'screen' => isset( $args['screen'] ) ? $args['screen'] : null,
 		) );
-		
+
 		$this->tab = isset( $args[ 'tab' ] ) ? $args[ 'tab' ] : '';
 
 		$status = isset( $_REQUEST['theme_status'] ) ? $_REQUEST['theme_status'] : 'all';
@@ -57,12 +57,12 @@ class MPSUM_Themes_List_Table extends MPSUM_List_Table {
 			return current_user_can( 'manage_network_themes' );
 	}
 
-	public function prepare_items() {		
+	public function prepare_items() {
 		global $totals, $status;
 		$order = 'DESC';
 		$page = isset( $_GET[ 'paged' ] ) ? absint( $_GET[ 'paged' ] ) : 1;
 		$orderby = 'Name';
-		
+
 		$themes = array(
 			/**
 			 * Filter the full array of WP_Theme objects to list in the Multisite
@@ -76,7 +76,7 @@ class MPSUM_Themes_List_Table extends MPSUM_List_Table {
 			'update_enabled' => array(),
 			'update_disabled' => array(),
 			'automatic' => array()
-			
+
 		);
 
 
@@ -92,23 +92,23 @@ class MPSUM_Themes_List_Table extends MPSUM_List_Table {
 					$themes[ 'automatic' ][ $theme ] = $theme_data;
 				}
 			}
-		}		
-		
+		}
+
 		$totals = array();
-		
-		foreach ( $themes as $type => $list ) 
+
+		foreach ( $themes as $type => $list )
 			$totals[ $type ] = count( $list );
-			
+
 		//Disable the automatic updates view
 		$core_options = MPSUM_Updates_Manager::get_options( 'core' );
 		if ( isset( $core_options[ 'automatic_theme_updates' ] ) && 'individual' !== $core_options[ 'automatic_theme_updates' ] ) {
 			unset( $totals[ 'automatic' ] );
 			$themes[ 'automatic' ] = array();
 		}
-			
+
 		if ( empty( $themes[ $status ] ) )
 			$status = 'all';
-			
+
 		$this->items = $themes[ $status ];
 		WP_Theme::sort_by_name( $this->items );
 
@@ -128,7 +128,7 @@ class MPSUM_Themes_List_Table extends MPSUM_List_Table {
 		}
 		$total_this_page = count( $themes[ 'all' ] );
 		$themes_per_page = 999;
-		
+
 		$start = ( $page - 1 ) * $themes_per_page;
 
 		if ( $total_this_page > $themes_per_page )
@@ -190,9 +190,9 @@ class MPSUM_Themes_List_Table extends MPSUM_List_Table {
 
 	public function no_items() {
 		if ( ! $this->has_items )
-			_e( 'No themes found.' );
+			_e( 'No themes found.', 'stops-core-theme-and-plugin-updates' );
 		else
-			_e( 'You do not appear to have any themes available at this time.' );
+			_e( 'You do not appear to have any themes available at this time.', 'stops-core-theme-and-plugin-updates' );
 	}
 
 	public function get_columns() {
@@ -200,8 +200,8 @@ class MPSUM_Themes_List_Table extends MPSUM_List_Table {
 
 		return array(
 			'cb'          => '<input type="checkbox" />',
-			'name'        => __( 'Theme' ),
-			'description' => __( 'Description' ),
+			'name'        => __( 'Theme', 'stops-core-theme-and-plugin-updates' ),
+			'description' => __( 'Description', 'stops-core-theme-and-plugin-updates' ),
 		);
 	}
 
@@ -219,7 +219,7 @@ class MPSUM_Themes_List_Table extends MPSUM_List_Table {
 
 			switch ( $type ) {
 				case 'all':
-					$text = _nx( 'All <span class="count">(%s)</span>', 'All <span class="count">(%s)</span>', $count, 'themes' );
+					$text = _nx( 'All <span class="count">(%s)</span>', 'All <span class="count">(%s)</span>', $count, , 'stops-core-theme-and-plugin-updates' );
 					break;
 				case 'update_disabled':
 					$text = _n( 'Updates Disabled <span class="count">(%s)</span>', 'Updates Disabled <span class="count">(%s)</span>', $count, 'stops-core-theme-and-plugin-updates' );
@@ -254,15 +254,15 @@ class MPSUM_Themes_List_Table extends MPSUM_List_Table {
 		global $status;
 
 		$actions = array();
-		        
-		$actions[ 'allow-update-selected' ] = esc_html__( 'Allow Updates', 'disable-plugin-and-theme-updates' );
-		$actions[ 'disallow-update-selected' ] = esc_html__( 'Disallow Updates', 'disable-plugin-and-theme-updates' );
+
+		$actions[ 'allow-update-selected' ] = esc_html__( 'Allow Updates', 'stops-core-theme-and-plugin-updates' );
+		$actions[ 'disallow-update-selected' ] = esc_html__( 'Disallow Updates', 'stops-core-theme-and-plugin-updates' );
 		$core_options = MPSUM_Updates_Manager::get_options( 'core' );
 		if ( isset( $core_options[ 'automatic_theme_updates' ] ) && 'individual' == $core_options[ 'automatic_theme_updates' ] ) {
-			$actions[ 'allow-automatic-selected' ] = esc_html__( 'Allow Automatic Updates', 'disable-plugin-and-theme-updates' );
-			$actions[ 'disallow-automatic-selected' ] = esc_html__( 'Disallow Automatic Updates', 'disable-plugin-and-theme-updates' );
+			$actions[ 'allow-automatic-selected' ] = esc_html__( 'Allow Automatic Updates', 'stops-core-theme-and-plugin-updates' );
+			$actions[ 'disallow-automatic-selected' ] = esc_html__( 'Disallow Automatic Updates', 'stops-core-theme-and-plugin-updates' );
 		}
-		
+
 		return $actions;
 	}
 
@@ -296,18 +296,18 @@ class MPSUM_Themes_List_Table extends MPSUM_List_Table {
 		$actions = apply_filters( 'mpsum_theme_action_links', array(), $theme, 'all' );
 
 		$checkbox_id = "checkbox_" . md5( $theme->get('Name') );
-		$checkbox = "<input type='checkbox' name='checked[]' value='" . esc_attr( $stylesheet ) . "' id='" . $checkbox_id . "' /><label class='screen-reader-text' for='" . $checkbox_id . "' >" . __('Select') . " " . $theme->display('Name') . "</label>";
+		$checkbox = "<input type='checkbox' name='checked[]' value='" . esc_attr( $stylesheet ) . "' id='" . $checkbox_id . "' /><label class='screen-reader-text' for='" . $checkbox_id . "' >" . __('Select', 'stops-core-theme-and-plugin-updates') . " " . $theme->display('Name') . "</label>";
 
 		$id = sanitize_html_class( $theme->get_stylesheet() );
 		$class = 'active';
 		$theme_options = MPSUM_Updates_Manager::get_options( 'themes' );
 		if ( false !== $key = array_search( $stylesheet, $theme_options ) ) {
 			$class = 'inactive';
-		} 
+		}
 		echo "<tr id='$id' class='$class'>";
 
 		list( $columns, $hidden ) = $this->get_column_info();
-		
+
 		foreach ( $columns as $column_name => $column_display_name ) {
 			$style = '';
 			if ( in_array( $column_name, $hidden ) )
@@ -325,7 +325,7 @@ class MPSUM_Themes_List_Table extends MPSUM_List_Table {
 				case 'description':
 					echo "<td class='column-description desc'$style>";
 					if ( $theme->errors() ) {
-						$pre = $status == 'broken' ? __( 'Broken Theme:' ) . ' ' : '';
+						$pre = $status == 'broken' ? __( 'Broken Theme:', 'stops-core-theme-and-plugin-updates' ) . ' ' : '';
 						echo '<p><strong class="attention">' . $pre . $theme->errors()->get_error_message() . '</strong></p>';
 					}
 					echo "<div class='theme-description'><p>" . $theme->display( 'Description' ) . "</p></div>
@@ -334,12 +334,12 @@ class MPSUM_Themes_List_Table extends MPSUM_List_Table {
 					$theme_meta = array();
 
 					if ( $theme->get('Version') )
-						$theme_meta[] = sprintf( __( 'Version %s' ), $theme->display('Version') );
+						$theme_meta[] = sprintf( __( 'Version %s', 'stops-core-theme-and-plugin-updates' ), $theme->display('Version') );
 
-					$theme_meta[] = sprintf( __( 'By %s' ), $theme->display('Author') );
+					$theme_meta[] = sprintf( __( 'By %s', 'stops-core-theme-and-plugin-updates' ), $theme->display('Author') );
 
 					if ( $theme->get('ThemeURI') )
-						$theme_meta[] = '<a href="' . $theme->display('ThemeURI') . '" title="' . esc_attr__( 'Visit theme homepage' ) . '">' . __( 'Visit Theme Site' ) . '</a>';
+						$theme_meta[] = '<a href="' . $theme->display('ThemeURI') . '" title="' . esc_attr__( 'Visit theme homepage', 'stops-core-theme-and-plugin-updates' ) . '">' . __( 'Visit Theme Site', 'stops-core-theme-and-plugin-updates' ) . '</a>';
 
 					/**
 					 * Filter the array of row meta for each theme in the Multisite themes


### PR DESCRIPTION
Some translations where pointing to the wrong text domain, while others had no text domain assigned at all. Hope I fetched them all.

However, the .pot file catalogue and translations need to be updated, too. I'll take care of that as soon as possible. Perhaps you can give me some feedback on the changes in this commit, especially whether I fetched all translations. I was kind of in a hurry.
