### PR TITLE
Trim emails, allowing white space after comma

### DIFF
--- a/includes/MPSUM_Admin_Core.php
+++ b/includes/MPSUM_Admin_Core.php
@@ -126,6 +126,7 @@ class MPSUM_Admin_Core {
 			$email_addresses_to_save = array();
 			if ( count( $email_addresses ) > 0 ) {
 				foreach( $email_addresses as $email ) {
+					$email = trim($email);
 					if ( ! is_email( $email ) && ! empty( $email ) ) {
 						$email_addresses_to_save = array();
 						$query_args[ 'bad_email' ] = 1;


### PR DESCRIPTION
"email1@domain.com, email2@domain.com" value for "options[email_addresses]" field gives an error.
Emails need to be trimmed, if not is_email() function gives an error.